### PR TITLE
Timeformats fix

### DIFF
--- a/jlib/date.go
+++ b/jlib/date.go
@@ -143,11 +143,7 @@ func parseTime(s string, picture string) (time.Time, error) {
 	// Replace -07:00 with Z07:00
 	layout = reMinus7.ReplaceAllString(layout, "Z$1")
 
-	// First remove the milliseconds from the date time string as it messes up our layouts
-	splitString := strings.Split(s, ".")
-	var dateTimeWithoutMilli = splitString[0]
-
-	var formattedTime = dateTimeWithoutMilli
+	var formattedTime = s
 	switch layout {
 	case time.DateOnly:
 		if len(formattedTime) > len(time.DateOnly) {
@@ -155,8 +151,14 @@ func parseTime(s string, picture string) (time.Time, error) {
 		}
 	case time.RFC3339:
 		// If the layout contains a time zone but the date string doesn't, lets remove it.
+		// Otherwise, if the layout contains a timezone and the time string doesn't add a default.
 		if !strings.Contains(formattedTime, "Z") {
 			layout = layout[:len(time.DateTime)]
+		} else {
+			formattedTimeWithTimeZone := strings.Split(formattedTime, "Z")
+			if len(formattedTimeWithTimeZone) == 2 {
+				formattedTime += "07:00"
+			}
 		}
 	}
 

--- a/jlib/date.go
+++ b/jlib/date.go
@@ -19,8 +19,11 @@ import (
 // 2006-01-02T15:04:05.000Z07:00
 const defaultFormatTimeLayout = "[Y]-[M01]-[D01]T[H01]:[m]:[s].[f001][Z01:01t]"
 
-const amSuffix = "am"
-const pmSuffix = "pm"
+const (
+	amSuffix = "am"
+	pmSuffix = "pm"
+	MST      = "07:00"
+)
 
 var defaultParseTimeLayouts = []string{
 	"[Y]-[M01]-[D01]T[H01]:[m]:[s][Z01:01t]",
@@ -151,13 +154,14 @@ func parseTime(s string, picture string) (time.Time, error) {
 		}
 	case time.RFC3339:
 		// If the layout contains a time zone but the date string doesn't, lets remove it.
-		// Otherwise, if the layout contains a timezone and the time string doesn't add a default.
+		// Otherwise, if the layout contains a timezone and the time string doesn't add a default
+		// The default is currently MST which is GMT -7.
 		if !strings.Contains(formattedTime, "Z") {
 			layout = layout[:len(time.DateTime)]
 		} else {
 			formattedTimeWithTimeZone := strings.Split(formattedTime, "Z")
 			if len(formattedTimeWithTimeZone) == 2 {
-				formattedTime += "07:00"
+				formattedTime += MST
 			}
 		}
 	}

--- a/jlib/date.go
+++ b/jlib/date.go
@@ -150,7 +150,9 @@ func parseTime(s string, picture string) (time.Time, error) {
 	var formattedTime = dateTimeWithoutMilli
 	switch layout {
 	case time.DateOnly:
-		formattedTime = formattedTime[:len(time.DateOnly)]
+		if len(formattedTime) > len(time.DateOnly) {
+			formattedTime = formattedTime[:len(time.DateOnly)]
+		}
 	case time.RFC3339:
 		// If the layout contains a time zone but the date string doesn't, lets remove it.
 		if !strings.Contains(formattedTime, "Z") {

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -7612,6 +7612,11 @@ func TestFuncMillis2(t *testing.T) {
 }
 
 func TestFuncToMillis(t *testing.T) {
+	defer func() { // added this to help with the test as it panics and that is annoying
+        if r := recover(); r != nil {
+            fmt.Println("Recovered in f", r)
+        }
+    }()
 
 	runTestCases(t, nil, []*testCase{
 		{

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -7613,10 +7613,10 @@ func TestFuncMillis2(t *testing.T) {
 
 func TestFuncToMillis(t *testing.T) {
 	defer func() { // added this to help with the test as it panics and that is annoying
-        if r := recover(); r != nil {
-            fmt.Println("Recovered in f", r)
-        }
-    }()
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
 
 	runTestCases(t, nil, []*testCase{
 		{
@@ -7633,7 +7633,7 @@ func TestFuncToMillis(t *testing.T) {
 		},
 		{
 			Expression: `$toMillis("foo")`,
-			Error:      fmt.Errorf(`could not parse time "foo"`),
+			Error:      fmt.Errorf(`could not parse time "foo" due to inconsistency in layout and date time string, date foo layout 2006`),
 		},
 	})
 }


### PR DESCRIPTION
There were some errors within the ToMilli function if you didn't pass down a picture and the time string contained a time zone