### PR TITLE
Allow empty arrays to be returned

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -205,9 +205,6 @@ func evalPath(node *jparse.PathNode, data reflect.Value, env *environment) (refl
 			return undefined, err
 		}
 
-		if jtypes.IsArray(output) && jtypes.Resolve(output).Len() == 0 {
-			return undefined, nil
-		}
 	}
 
 	if node.KeepArrays {

--- a/jsonata_test.go
+++ b/jsonata_test.go
@@ -621,6 +621,18 @@ func TestArraySelectors4(t *testing.T) {
 
 }
 
+func TestEmptyArray(t *testing.T) {
+	data := map[string]any{
+		"thing": []any{},
+	}
+	runTestCases(t, data, []*testCase{
+		{
+			Expression: "thing",
+			Output:     []any{},
+		},
+	})
+}
+
 func TestQuotedSelectors(t *testing.T) {
 
 	runTestCases(t, testdata.foobar, []*testCase{


### PR DESCRIPTION
In Jsonata it is a valid response return `[]any{}` from a transform, but this was previously filtered out.

For example, in jsonata-js, the following input and transform result in a response of `[]`.
Input:
```
{
  "Account": {
    "Account Name": "Firefly",
    "Order": [
    ]
  }
}
```
Transform: "Account.Order"

The same data and transform resulted in a "no results found" error in jsonata-go.