### PR TITLE
Fix expressions with constants ending in "." fail to compile

### DIFF
--- a/jsonata.go
+++ b/jsonata.go
@@ -463,7 +463,7 @@ func isDigit(r rune) bool {
 */
 
 var (
-	reQuotedPath      = regexp.MustCompile(`([A-Za-z\$\\*\` + "`" + `])\.[\"']([\s\S]+?)[\"']`)
+	reQuotedPath      = regexp.MustCompile(`([\"'\]\$\\*\x60 + "\x60" + \x60])\.[\"']([A-Za-z\s\d_-]+?)[\"']`)
 	reQuotedPathStart = regexp.MustCompile(`^[\"']([ \.0-9A-Za-z]+?)[\"']\.([A-Za-z\$\*\"\'])`)
 	commentsPath      = regexp.MustCompile(`\/\*([\s\S]*?)\*\/`)
 )


### PR DESCRIPTION
We encountered a problem where any expression containing a constant ending in a dot followed by another value fails to compile. A simple example would be:

```
{
    "key1": "value1.",
    "key2": "value2"
}
```

This fails to compile complaining about a missing brace. Removing the "." in value1 fixes the issue.

It looks like the `replaceQuotesAndCommentsInPaths` function uses a regex to replace the double quotes with backticks on the JSONata path. `replaceQuotesAndCommentsInPaths` returns:

```
{
    "key1": "value1.`,
    `key2": "value2"
}
```

My proposed change modifies the regex to avoid this while still handling the quote replacement. I'm not 100% sure of the intent of the original code, so if I'm missing something, I'm happy to keep working on this.
